### PR TITLE
Improved logging in case of error

### DIFF
--- a/cli.go
+++ b/cli.go
@@ -128,10 +128,6 @@ func (a *App) runCmd(cmd *cobra.Command, args []string) {
 	//points, _, fragment, err := Process(data, c.Process.Iterator, sink.Point{}, true)
 	points, _, _, err := Process(data, c.Process.Iterator, sink.Point{}, false)
 	exitOnErr(err)
-	if err != nil {
-		fmt.Println(err.Error())
-		os.Exit(1)
-	}
 
 	if a.cfg.run.stopAfter == StepProcess.String() {
 		info("Printing extracted points to STDOUT and last iterator fragment to STDERR and exiting...")

--- a/config.go
+++ b/config.go
@@ -28,10 +28,10 @@ func (v Validators) ValidateContent(data []byte) (bool, []error) {
 		}
 
 		value := string(v)
-		if value != check.Expect {
-			ok = false
-			err = fmt.Errorf("value at '%s' is expected to be '%s', is '%s'", check.Selector, value, check.Expect)
-			errs = append(errs, err)
+			if value != check.Expect {
+				ok = false
+				err = fmt.Errorf("value at '%s' is expected to be '%s', is '%s'", check.Selector, check.Expect, value)
+				errs = append(errs, err)
 		}
 	}
 	return ok, errs

--- a/internal/inputreader/input.go
+++ b/internal/inputreader/input.go
@@ -91,7 +91,7 @@ func (in Input) Fetch() ([]byte, error) {
 	} else if u.Scheme == "http" || u.Scheme == "https" {
 		data, status, err = readHypertext(in.URL, in.Body, in.Method, in.Headers)
 		if err == nil && in.HTTPExpectStatus != 0 && status != in.HTTPExpectStatus {
-			return data, fmt.Errorf("HTTP status code is %d, %d was expected", status, in.HTTPExpectStatus)
+			return data, fmt.Errorf("HTTP status code is %d, %d was expected.\n%s", status, in.HTTPExpectStatus, string(data))
 		}
 		return data, err
 	} else if u.Scheme == "s3" {


### PR DESCRIPTION
When the remote input HTTP returns an error also prints the HTTP response
body.